### PR TITLE
Variables on Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN virtualenv /env && /env/bin/pip install --no-cache-dir -r /app/requirements.
 
 VOLUME ["/opt/docker-compose-projects"]
 
-COPY demo-projects /opt/docker-compose-projects
+COPY docker-compose-ui-projects /opt/docker-compose-projects
 
 EXPOSE 5000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN virtualenv /env && /env/bin/pip install --no-cache-dir -r /app/requirements.
 
 VOLUME ["/opt/docker-compose-projects"]
 
-COPY docker-compose-ui-projects /opt/docker-compose-projects
+#COPY docker-compose-ui-projects /opt/docker-compose-projects
+COPY demo-projects /opt/docker-compose-projects
 
 EXPOSE 5000
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 
 
 build:
-	docker build -t allamand/docker-compose-ui .
+	git clone https://gitlab.pic.s1.p.fti.net/dfyarchicloud/docker-compose-ui-projects.git
+	docker build -t sebmoule/docker-compose-ui .
+	rm -rf docker-compose-ui-projects
 
 
 rebase:

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,7 @@
 
 build:
 	docker build -t allamand/docker-compose-ui .
+
+
+rebase:
+	git rebase francescou/master

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+
+
+build:
+	docker build -t allamand/docker-compose-ui .

--- a/scripts/bridge.py
+++ b/scripts/bridge.py
@@ -81,12 +81,6 @@ def get_yml_path(path):
     return get_default_config_files(path)[0]
 
 def get_project(path):
-    """
-    get docker project given file path
-    add locale env car defined in file path/.env to docker-compose then cleanup
-    """
-    logging.debug('get project ' + path)
-    environment = Environment.from_env_file(path)
 
     """ 
     apply env var for docker-compose.yml substitutions
@@ -97,6 +91,14 @@ def get_project(path):
     for key, value in localenv.iteritems():
         logging.debug('environment: ' + key + ' ' + value)
         os.environ[key] = value
+
+    """
+    get docker project given file path
+    add locale env car defined in file path/.env to docker-compose then cleanup
+    """
+    logging.debug('get project ' + path)
+    environment = Environment.from_env_file(path)
+
 
     config_path = get_config_path_from_options(path, dict(), environment)
     project = compose_get_project(path, config_path)

--- a/scripts/bridge.py
+++ b/scripts/bridge.py
@@ -3,6 +3,9 @@ bridge to docker-compose
 """
 
 import logging
+import os
+import codecs
+import six
 from compose.container import Container
 from compose.cli.command import get_project as compose_get_project, get_config_path_from_options
 from compose.config.config import get_default_config_files
@@ -11,6 +14,31 @@ from compose.config.environment import Environment
 from compose.cli.docker_client import docker_client
 from compose.const import API_VERSIONS
 from compose.config.config import V2_0
+
+def split_env(env):
+    if isinstance(env, six.binary_type):
+        env = env.decode('utf-8', 'replace')
+    if '=' in env:
+        return env.split('=', 1)
+    else:
+        return env, None
+
+def env_vars_from_file(filename):
+    """
+    Read in a line delimited file of environment variables.
+    """
+    env = {}
+    if not os.path.exists(filename):
+        return env
+    elif not os.path.isfile(filename):
+        return env
+    for line in codecs.open(filename, 'r', 'utf-8'):
+        line = line.strip()
+        if line and not line.startswith('#'):
+            k, v = split_env(line)
+            env[k] = v
+    return env
+
 
 def ps_(project):
     """
@@ -55,11 +83,31 @@ def get_yml_path(path):
 def get_project(path):
     """
     get docker project given file path
+    add locale env car defined in file path/.env to docker-compose then cleanup
     """
     logging.debug('get project ' + path)
     environment = Environment.from_env_file(path)
+
+    """ 
+    apply env var for docker-compose.yml substitutions
+    """
+    globalenv = env_vars_from_file(path + "/../compose-projects.env")
+    localenv = env_vars_from_file(path + "/.env")
+    localenv.update(globalenv)
+    for key, value in localenv.iteritems():
+        logging.debug('environment: ' + key + ' ' + value)
+        os.environ[key] = value
+
     config_path = get_config_path_from_options(path, dict(), environment)
     project = compose_get_project(path, config_path)
+
+    """ 
+    clean-up locale env var
+    """
+    for key, value in localenv.iteritems():
+        logging.debug('cleanup: ' + key + ' ' + value)
+        del os.environ[key]
+
     return project
 
 def containers():

--- a/scripts/git_repo.py
+++ b/scripts/git_repo.py
@@ -10,7 +10,7 @@ git_repo = os.getenv('GIT_REPO')
 
 logging.basicConfig(level=logging.DEBUG)
 
-GIT_YML_PATH = '/opt/docker-compose-projects-git/'
+GIT_YML_PATH = '/opt/docker-compose-projects/'
 
 def git_pull():
     """


### PR DESCRIPTION
Hi this pull request may be a respond to issue #31 

It add the ability for docker-compose to be configured with : 
 - a global env file for all projects at path /path/docker-projects/compose-projects.env
 - an additional project specific env file at path /path/to/docker-projects/<project>/.env

I'm very new on python dev, so don't hesitate to comment on the how I do it I can change with no problem.