### PR TITLE
add docker create button

### DIFF
--- a/main.py
+++ b/main.py
@@ -283,6 +283,16 @@ def yml():
     return jsonify(response.json())
 
 
+@app.route(API_V1 + "create", methods=['POST'])
+@requires_auth
+def create():
+    """
+    docker-compose create
+    """
+    name = loads(request.data)["id"]
+    get_project_with_name(name).create()
+    return jsonify(command='create')
+
 @app.route(API_V1 + "start", methods=['POST'])
 @requires_auth
 def start():

--- a/main.py
+++ b/main.py
@@ -222,9 +222,9 @@ def build():
 
     return jsonify(command='build')
 
-@app.route(API_V1 + "create", methods=['POST'])
+@app.route(API_V1 + "create-project", methods=['POST'])
 @requires_auth
-def create():
+def create_project():
     """
     create new project
     """

--- a/static/scripts/controllers/create.js
+++ b/static/scripts/controllers/create.js
@@ -11,8 +11,8 @@ angular.module('composeUiApp')
   .controller('CreateCtrl', function ($scope, $routeParams, $resource, $location) {
 
       var Projects = $resource('api/v1/projects', null, {
-          'create': {
-              url: 'api/v1/create',
+          'createProject': {
+              url: 'api/v1/create-project',
               method: 'POST'
           }
       });
@@ -20,10 +20,10 @@ angular.module('composeUiApp')
       var Search = $resource('api/v1/search');
       var Yml = $resource('api/v1/yml');
 
-      $scope.create = function (name, yml) {
+      $scope.createProject = function (name, yml) {
 
       //TODO: check if name is alphanumeric
-          Projects.create({
+          Projects.createProject({
               name: name,
               yml: yml
           }, function (data) {

--- a/static/scripts/directives/actions.js
+++ b/static/scripts/directives/actions.js
@@ -19,6 +19,10 @@ angular.module('composeUiApp')
                       url: 'api/v1/build',
                       method: 'POST'
                   },
+                  'create': {
+                      url: 'api/v1/create',
+                      method: 'POST'
+                  },
                   'start': {
                       url: 'api/v1/start',
                       method: 'POST'
@@ -63,6 +67,10 @@ angular.module('composeUiApp')
               };
               $scope.down = function () {
                   updateProjectStatus(Project.down, 'project down');
+              };
+
+              $scope.create = function () {
+                  updateProjectStatus(Project.create, 'project created');
               };
 
               $scope.start = function () {

--- a/static/views/actions.html
+++ b/static/views/actions.html
@@ -7,6 +7,7 @@
 <div class="btn-group" role="group" aria-label="actions">
   <button ng-click="kill()" class="btn btn-default"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span> kill</button>
   <button ng-click="stop()" class="btn btn-default"><span class="glyphicon glyphicon-stop" aria-hidden="true"></span> stop</button>
+  <button ng-click="create()" class="btn btn-default"><span class="glyphicon glyphicon-send" aria-hidden="true"></span> create</button>
   <button ng-click="start()" class="btn btn-default"><span class="glyphicon glyphicon-play" aria-hidden="true"></span> start</button>
   <button ng-click="restart()" class="btn btn-default"><span class="glyphicon glyphicon-refresh" aria-hidden="true"></span> restart</button>
 </div>

--- a/static/views/create.html
+++ b/static/views/create.html
@@ -37,7 +37,7 @@
   <div class="panel panel-default">
       <div class="panel-heading">project metadata</div>
       <div class="panel-body project-wizard">
-        <form class="form-horizontal" ng-submit="create(name, yml)">
+        <form class="form-horizontal" ng-submit="createProject(name, yml)">
           <div class="form-group">
             <label for="projectName">Name</label>
             <input type="text" ng-model="name" class="form-control" id="projectName" placeholder="Project Name" required>


### PR DESCRIPTION
Hi Francesco,

I was missing the `docker-compose create` feature, so here is my proposal. 
As the "create" route was already existing for the "create project", I renamed it as "create-project".
Sorry, I couldn't find a better icon for the button...

Note that the `docker-compose create` command doesn't create the network. It's up to the `docker-compose up` command. So either create manually your own network before, or use the `network_mode` option in the "docker-compose.yml" file.

Pierre