### PR TITLE
Add simple textarea for environment variables

### DIFF
--- a/main.py
+++ b/main.py
@@ -235,7 +235,7 @@ def create_project():
     file_path = manage(YML_PATH + '/' +  data["name"], data["yml"], False)
 
     if 'env' in data and data["env"]:
-        file_path = directory + "/.env"
+        file_path = YML_PATH + '/' + data["name"] + "/.env"
         out_file = open(file_path, "w")
         out_file.write(data["env"])
         out_file.close()

--- a/main.py
+++ b/main.py
@@ -235,10 +235,9 @@ def create_project():
     file_path = manage(YML_PATH + '/' +  data["name"], data["yml"], False)
 
     if 'env' in data and data["env"]:
-        file_path = YML_PATH + '/' + data["name"] + "/.env"
-        out_file = open(file_path, "w")
-        out_file.write(data["env"])
-        out_file.close()
+        env_file = open(YML_PATH + '/' + data["name"] + "/.env", "w")
+        env_file.write(data["env"])
+        env_file.close()
 
     load_projects()
 

--- a/main.py
+++ b/main.py
@@ -234,6 +234,12 @@ def create_project():
 
     file_path = manage(YML_PATH + '/' +  data["name"], data["yml"], False)
 
+    if 'env' in data and data["env"]:
+        file_path = directory + "/.env"
+        out_file = open(file_path, "w")
+        out_file.write(data["env"])
+        out_file.close()
+
     load_projects()
 
     return jsonify(path=file_path)

--- a/static/scripts/controllers/create.js
+++ b/static/scripts/controllers/create.js
@@ -20,12 +20,13 @@ angular.module('composeUiApp')
       var Search = $resource('api/v1/search');
       var Yml = $resource('api/v1/yml');
 
-      $scope.createProject = function (name, yml) {
+      $scope.createProject = function (name, yml, env) {
 
       //TODO: check if name is alphanumeric
           Projects.createProject({
               name: name,
-              yml: yml
+              yml: yml,
+              env: env
           }, function (data) {
               alertify.success('created project: ' + name + ', path: ' + data.path);
               $scope.$parent.reload(false);

--- a/static/views/create.html
+++ b/static/views/create.html
@@ -37,7 +37,7 @@
   <div class="panel panel-default">
       <div class="panel-heading">project metadata</div>
       <div class="panel-body project-wizard">
-        <form class="form-horizontal" ng-submit="createProject(name, yml)">
+        <form class="form-horizontal" ng-submit="createProject(name, yml, env)">
           <div class="form-group">
             <label for="projectName">Name</label>
             <input type="text" ng-model="name" class="form-control" id="projectName" placeholder="Project Name" required>
@@ -46,6 +46,12 @@
             <label for="yml">YML Content</label>
 
             <textarea class="form-control" ng-model="yml" id="yml" rows="20" required></textarea>
+
+          </div>
+          <div class="form-group">
+            <label for="yml">Environment Variables</label>
+
+            <textarea class="form-control" ng-model="env" id="env" rows="20"></textarea>
 
           </div>
           <button type="submit" class="btn btn-primary">Create new project</button>


### PR DESCRIPTION
Fixes #31 

This adds a simple textarea for env variables when creating a new project. This should be fully BC - if no "env" parameter is given to the API (or it is falsy/blank), then no ".env" file is created.