### PR TITLE
Run command in container

### DIFF
--- a/main.py
+++ b/main.py
@@ -109,6 +109,25 @@ def run_exec(container_id):
         container_id=container.id \
         )
 
+@app.route(API_V1 + "exec/<container_id>/<exec_id>", methods=['GET'])
+@requires_auth
+def inspect_exec(container_id, exec_id):
+    """
+    Inspect a one-off exec command ran with `run_exec`.
+    """
+
+    container = get_container_from_id(client(), container_id)
+    r = client().exec_inspect(exec_id)
+
+    return jsonify(\
+        id=exec_id, \
+        running=r.get('Running'), \
+        code=r.get('ExitCode'), \
+        pid=r.get('Pid'), \
+        container_id=r.get('ContainerID') \
+        )
+
+
 @app.route(API_V1 + "projects/<project>/<service_id>", methods=['POST'])
 @requires_auth
 def run_service(project, service_id):

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ import docker
 import requests
 from flask import Flask, jsonify, request
 from scripts.git_repo import git_pull, git_repo, GIT_YML_PATH
-from scripts.bridge import ps_, get_project, get_container_from_id, get_yml_path, containers, project_config, info
+from scripts.bridge import ps_, get_project, get_container_from_id, get_yml_path, containers, project_config, info, client
 from scripts.find_files import find_yml_files, get_readme_file, get_logo_file
 from scripts.requires_auth import requires_auth, authentication_enabled, \
   disable_authentication, set_authentication
@@ -78,6 +78,36 @@ def project_containers(name):
     """
     project = get_project_with_name(name)
     return jsonify(containers=ps_(project))
+
+@app.route(API_V1 + "exec/<container_id>", methods=['POST'])
+@requires_auth
+def run_exec(container_id):
+    """
+    Run a one-off exec command in a specific container specified by the
+    "container_id" param.
+    """
+
+    json = loads(request.data)
+
+    if 'command' not in json:
+        raise Exception('run_exec expects command to be set in JSON body')
+
+    command = json['command']
+    container = get_container_from_id(client(), container_id)
+
+    r = container.create_exec(command)
+
+    if 'Id' not in r:
+        raise Exception('Unable to create exec for command "%s"' % command)
+
+    container.start_exec(r['Id'], detach=True)
+
+    return jsonify(\
+        id=r['Id'], \
+        command=command, \
+        container=container.name, \
+        container_id=container.id \
+        )
 
 @app.route(API_V1 + "projects/<project>/<service_id>", methods=['POST'])
 @requires_auth

--- a/static/scripts/directives/project-detail.js
+++ b/static/scripts/directives/project-detail.js
@@ -19,7 +19,6 @@ angular.module('composeUiApp')
               });
 
 
-
               var Host = $resource('api/v1/host');
               var Yml = $resource('api/v1/projects/yml/:id');
               var Readme = $resource('api/v1/projects/readme/:id');
@@ -55,6 +54,25 @@ angular.module('composeUiApp')
                       $scope.containerLogs = id;
                       $scope.showDialog = true;
                       $scope.logs = data.logs;
+                  });
+              };
+
+              var Exec = $resource('api/v1/exec/:container');
+
+              $scope.showRunCommand = function (container) {
+                  $scope.container = container;
+                  $scope.showRunDialog = true;
+              };
+              $scope.runCommand = function (container_id, command) {
+                  Exec.save({
+                      container: container_id
+                  }, {
+                      command: command 
+                  }, function(r) {
+                      alertify.success('`' + r.command + '` running in ' + r.container + '.');
+                      // TODO perhaps set an interval checking for a successful exit code? (see: ExecInspect API endpoint)
+                  }, function() {
+                      alertify.error('Error running `' + command + '`');
                   });
               };
 

--- a/static/views/project-detail.html
+++ b/static/views/project-detail.html
@@ -60,6 +60,7 @@
             <button class="btn btn-xs btn-default" ng-click="displayLogs(container.name)">logs</button>
             <a class="btn btn-xs btn-default" ng-href="#/project/{{projectId}}/{{container.name}}">details</a>
             <button class="btn btn-xs btn-default" ng-click="rebuild(id)">rebuild</button>
+            <button class="btn btn-xs btn-default" ng-click="showRunCommand(container)">run</button>
           </div>
           <div class="panel-body">
 
@@ -102,6 +103,26 @@
         </div>
       </div>
     </div>
+  </div>
+  <div modal-show="showRunDialog" class="modal fade" tabindex="-1">
+    <form class="form-horizontal" ng-submit="runCommand(container.name, command)">
+        <div class="modal-dialog modal-lg" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+              <h4 class="modal-title">Run in {{container.name}}</h4>
+            </div>
+            <div class="modal-body">
+              <div class="form-group">
+                <input type="text" ng-model="command" class="form-control" id="command" placeholder="Command to run..." required>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="submit" class="btn btn-primary">Run</button>
+            </div>
+          </div>
+        </div>
+    </form>
   </div>
   <span ng-show="isEmpty(services)">no containers found</span>
 </div>


### PR DESCRIPTION
This adds the "run_exec" and "inspect_exec" API endpoints, as well as the corresponding frontend-UI.

Use case is to run a one-off command in a specific container. For example, for some of our docker-compose projects, we want to re-run "provision" (which is our puppet provisioner) without deleting/restarting the container.