### PR TITLE
Save .env content even on update project

### DIFF
--- a/main.py
+++ b/main.py
@@ -259,6 +259,12 @@ def update_project():
     """
     data = loads(request.data)
     file_path = manage(YML_PATH + '/' +  data["name"], data["yml"], True)
+
+    if 'env' in data and data["env"]:
+        env_file = open(YML_PATH + '/' + data["name"] + "/.env", "w")
+        env_file.write(data["env"])
+        env_file.close()
+
     return jsonify(path=file_path)
 
 


### PR DESCRIPTION
Would be useful to update even the docs at https://francescou.github.io/docker-compose-ui/api.html documenting the `env` param, but it seems that is not in the same repository.